### PR TITLE
Fix: 저번 팀 미팅에서 받은 피드백 반영함, ShareButton URL 변경 및 모달창 뒤로가기 원상복구

### DIFF
--- a/src/Pages/FeedPage/index.jsx
+++ b/src/Pages/FeedPage/index.jsx
@@ -2,17 +2,12 @@ import { Link } from "react-router-dom";
 import Modalsection from "../../components/FeedPage/ModalSection";
 import FeedPageProfile from "../../components/FeedPage/FeedPageProfile";
 import ShareButtons from "../../components/common/ShareButtons";
-import { useLocation } from "react-router-dom";
-import { BASIC_DEPLOY_URL } from "../../constants/constants";
 import { useSearchParams } from "react-router-dom";
 import { useParams } from "react-router-dom";
 import FeedCardList from "../../components/common/FeedCardList.jsx/index.jsx";
 
 const FeedPage = () => {
   const { id } = useParams();
-  const currentLocation = useLocation();
-  const currentPath = currentLocation.pathname;
-  const currentUrl = `${BASIC_DEPLOY_URL}${currentPath}`;
   const [searchParams, setSearchParams] = useSearchParams();
 
   return (
@@ -21,7 +16,7 @@ const FeedPage = () => {
       <Link to="/list">리스트 페이지</Link>
       <Link to={`/post/${id}/answer`}>답변 페이지</Link>
       <FeedPageProfile subjectId={id} />
-      <ShareButtons url={currentUrl} />
+      <ShareButtons id={id} />
       <FeedCardList subjectId={id} />
       <Modalsection
         subjectId={id}

--- a/src/Pages/FeedPage/index.jsx
+++ b/src/Pages/FeedPage/index.jsx
@@ -2,13 +2,11 @@ import { Link } from "react-router-dom";
 import Modalsection from "../../components/FeedPage/ModalSection";
 import FeedPageProfile from "../../components/FeedPage/FeedPageProfile";
 import ShareButtons from "../../components/common/ShareButtons";
-import { useSearchParams } from "react-router-dom";
 import { useParams } from "react-router-dom";
 import FeedCardList from "../../components/common/FeedCardList.jsx/index.jsx";
 
 const FeedPage = () => {
   const { id } = useParams();
-  const [searchParams, setSearchParams] = useSearchParams();
 
   return (
     <div>
@@ -18,11 +16,7 @@ const FeedPage = () => {
       <FeedPageProfile subjectId={id} />
       <ShareButtons id={id} />
       <FeedCardList subjectId={id} />
-      <Modalsection
-        subjectId={id}
-        searchParams={searchParams}
-        setSearchParams={setSearchParams}
-      />
+      <Modalsection subjectId={id} />
     </div>
   );
 };

--- a/src/components/FeedPage/ModalSection/index.jsx
+++ b/src/components/FeedPage/ModalSection/index.jsx
@@ -22,7 +22,7 @@ const ContentsBox = styled.div`
   background-color: white;
 `;
 
-const Modal = ({ subjectId, searchParams, setSearchParams }) => {
+const Modal = ({ subjectId, setIsModalOpen }) => {
   const [isDisabled, setIsDisabled] = useState(true);
   const {
     data: profileData,
@@ -37,14 +37,12 @@ const Modal = ({ subjectId, searchParams, setSearchParams }) => {
 
   const handleBGCloseClick = (event) => {
     if (event.target === modalBg.current) {
-      searchParams.delete("isModal");
-      setSearchParams(searchParams);
+      setIsModalOpen(false);
     }
   };
 
   const handleBtnCloseClick = () => {
-    searchParams.delete("isModal");
-    setSearchParams(searchParams);
+    setIsModalOpen(false);
   };
 
   const handleChange = (event) => {
@@ -104,23 +102,18 @@ const Modal = ({ subjectId, searchParams, setSearchParams }) => {
   );
 };
 
-const Modalsection = ({ subjectId, searchParams, setSearchParams }) => {
-  const isModalOpen = searchParams.get("isModal") === "open";
+const Modalsection = ({ subjectId }) => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleOpenClick = () => {
-    searchParams.set("isModal", "open");
-    setSearchParams(searchParams);
+    setIsModalOpen(true);
   };
 
   return (
     <>
       <button onClick={handleOpenClick}>질문하실?</button>
       {isModalOpen && (
-        <Modal
-          subjectId={subjectId}
-          searchParams={searchParams}
-          setSearchParams={setSearchParams}
-        />
+        <Modal setIsModalOpen={setIsModalOpen} subjectId={subjectId} />
       )}
     </>
   );

--- a/src/components/common/KakaoShareButton/index.jsx
+++ b/src/components/common/KakaoShareButton/index.jsx
@@ -1,4 +1,5 @@
 import { useEffect } from "react";
+import { BASIC_DEPLOY_URL } from "../../../constants/constants";
 
 const KakaoShareButton = ({ url }) => {
   useEffect(() => {
@@ -25,6 +26,13 @@ const KakaoShareButton = ({ url }) => {
           link: {
             mobileWebUrl: url,
             webUrl: url,
+          },
+        },
+        {
+          title: "솔직하게 질문 받기",
+          link: {
+            mobileWebUrl: BASIC_DEPLOY_URL,
+            webUrl: BASIC_DEPLOY_URL,
           },
         },
       ],

--- a/src/components/common/ShareButtons/index.jsx
+++ b/src/components/common/ShareButtons/index.jsx
@@ -1,8 +1,11 @@
 import { FacebookIcon, FacebookShareButton } from "react-share";
 import UrlShareButton from "../UrlShareButton";
 import KakaoShareButton from "../KakaoShareButton";
+import { BASIC_DEPLOY_URL } from "../../../constants/constants";
 
-const ShareButtons = ({ url }) => {
+const ShareButtons = ({ id }) => {
+  const url = `${BASIC_DEPLOY_URL}/post/${id}`;
+
   return (
     <div>
       <UrlShareButton url={url} />


### PR DESCRIPTION
## 개요
<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->
1. 저번 팀 미팅에서 이야기 한대로 공유주소는 FeedPage로 통일했습니다. 쉐어 버튼 클릭 시 현재 화면의 id 값만 받아와 해당 피드 페이지로 공유 됩니다. 추가로 카카오톡 공유하기로 보낸 메세지에 질문 하기 , 질문 받기 이렇게 2개로 변경했습니다. 질문하기는 피드 페이지로 질문 받기는 신규 유저 유입을 위해 메인으로 연결됩니다.
2. 멘토님 조언대로 일단 PC 사용자 우선으로 개발하기로 했고, 모달창 뒤로가기 막기위해 query string으로 조작하던거 원상 복구했습니다. 추후 프로젝트 완성 후 시간이 남으면 모바일 유저를 위해 android, ios 구분하여 뒤로가기 막기 기능 구현 할 예정입니다.
<!---- Resolves: #(Isuue Number) -->

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제
