### PR TITLE
FeedContainer 수정, AnswerFeedCard 기능 추가 

### DIFF
--- a/src/Pages/AnswerPage/index.jsx
+++ b/src/Pages/AnswerPage/index.jsx
@@ -39,7 +39,7 @@ const AnswerPage = () => {
       <Badge>가나다</Badge>
       <Reaction />
       <MoreDropdown />
-      <FeedContainer subjectId={id} />
+      <FeedContainer subjectId={id} cardType="answerFeed" />
       <BasicFloatingButton disabled>제출하기</BasicFloatingButton>
       <BasicFloatingButton>제출하기</BasicFloatingButton>
       <DeleteFloatingButton handleDelete={handleFeedDelete} />

--- a/src/components/AnswerPage/AnswerFeedCard/index.jsx
+++ b/src/components/AnswerPage/AnswerFeedCard/index.jsx
@@ -1,10 +1,11 @@
+import { useState, useEffect } from "react";
 import styled from "styled-components";
+import useRequest from "@hooks/useRequest";
 import FeedPageProfile from "@components/common/FeedPageProfile";
 import Reaction from "@components/common/Reaction";
 import getTimeDiff from "@components/common/FeedCard/getTimeDiff";
 import Badge from "../../common/Badge";
-// import InputTextareaForm from "@components/common/InputTextAreaForm";
-import useRequest from "@hooks/useRequest";
+import InputTextareaForm from "@components/common/InputTextareaForm";
 import MoreDropdown from "../MoreDropdown";
 
 const ContainDiv = styled.div`
@@ -15,6 +16,8 @@ const ContainDiv = styled.div`
 `;
 
 const FeedCard = ({ feedCardData, isLoading }) => {
+  const [answerContent, setAnswerContent] = useState(null);
+
   const {
     id: questionId,
     content: questionContent,
@@ -39,12 +42,19 @@ const FeedCard = ({ feedCardData, isLoading }) => {
     useSubmitAnswer({ content: value, isRejected: false });
   };
 
+  useEffect(() => {
+    setAnswerContent(answer);
+    if (submitAnswerResponse) {
+      setAnswerContent(submitAnswerResponse);
+    }
+  }, [submitAnswerResponse]);
+
   return (
     <ContainDiv>
       {/* 답변완료 */}
       <div>
-        {feedCardData && answer ? <Badge isAnswered /> : <Badge />}
-        <MoreDropdown isAnswered={answer} />
+        {feedCardData && answerContent ? <Badge isAnswered /> : <Badge />}
+        <MoreDropdown isAnswered={answerContent} answerId={answerContent?.id} />
       </div>
 
       {/* 질문 */}
@@ -55,20 +65,21 @@ const FeedCard = ({ feedCardData, isLoading }) => {
         </div>
       )}
       {/* 답변 */}
-      {feedCardData && answer ? (
+      {feedCardData && answerContent ? (
         <div>
           <FeedPageProfile subjectId={subjectId} />
-          {answer?.isRejected ? (
+          {answerContent?.isRejected ? (
             <p style={{ color: "red" }}>답변거절</p>
           ) : (
-            <p>{answer?.content}</p>
+            <p>{answerContent && answerContent?.content}</p>
           )}
         </div>
-      ) : // <InputTextareaForm
-      //   formType="answer"
-      //   handleSubmit={handleSubmitAnswer}
-      // />
-      null}
+      ) : (
+        <InputTextareaForm
+          formType="answer"
+          handleSubmit={handleSubmitAnswer}
+        />
+      )}
       <Reaction
         questionId={feedCardData?.id}
         like={feedCardData?.like}

--- a/src/components/AnswerPage/MoreDropdown/index.jsx
+++ b/src/components/AnswerPage/MoreDropdown/index.jsx
@@ -6,9 +6,17 @@ import { ReactComponent as DeleteIcon } from "@icons/Close.svg";
 import { ReactComponent as RejectionIcon } from "@icons/Rejection.svg";
 import IconTextButton from "../../common/IconTextButton";
 import styled from "styled-components";
+import useRequest from "@hooks/useRequest";
 
 const BasicMoreDropdown = ({ className, id, isAnswered, answerId }) => {
   const { btnRef, isOpen, clickHandler } = useDropdown();
+
+  const {
+    data: deleteResponse,
+    isLoading,
+    error,
+    request: useDeleteAnswer,
+  } = useRequest({ url: `answers/${answerId}`, method: "DELETE" });
 
   const moreEditableOptions = [
     {
@@ -32,6 +40,7 @@ const BasicMoreDropdown = ({ className, id, isAnswered, answerId }) => {
       ),
       event: (e) => {
         console.log("삭제하기");
+        useDeleteAnswer();
       },
       active: false,
     },

--- a/src/components/common/FeedContainer/index.jsx
+++ b/src/components/common/FeedContainer/index.jsx
@@ -4,9 +4,14 @@ import useRequest from "@hooks/useRequest";
 import { boxStyles, colors, devices } from "@styles/styleVariables";
 import FeedCountMessage from "@components/common/FeedCountMessage";
 import NoFeedCard from "@components/common/NoFeedCard";
-import FeedCard from "../../AnswerPage/AnswerFeedCard";
+import AnswerFeedCard from "@components/AnswerPage/AnswerFeedCard";
+import FeedCard from "../FeedCard";
 
-const BasicFeedContainer = ({ className, subjectId }) => {
+const BasicFeedContainer = ({
+  className,
+  subjectId,
+  cardType = "basicFeed",
+}) => {
   const {
     data: feedCardData,
     isLoading,
@@ -44,7 +49,12 @@ const BasicFeedContainer = ({ className, subjectId }) => {
         <ul>
           {feedCardList?.map((data) => (
             <li key={data?.id}>
-              <FeedCard feedCardData={data} isLoading={isLoading} />
+              {cardType === "basicFeed" ? (
+                <FeedCard />
+              ) : (
+                <AnswerFeedCard feedCardData={data} isLoading={isLoading} />
+              )}
+              {/* <FeedCard feedCardData={data} isLoading={isLoading} /> */}
             </li>
           ))}
         </ul>

--- a/src/components/common/InputTextareaForm/constant.js
+++ b/src/components/common/InputTextareaForm/constant.js
@@ -4,11 +4,11 @@ const inputText = {
     button: "질문 보내기",
   },
   answer: {
-    placehodler: "답변을 입력해주세요",
+    placeholder: "답변을 입력해주세요",
     button: "답변 완료",
   },
   modify: {
-    placehodler: "답변을 입력해주세요",
+    placeholder: "답변을 입력해주세요",
     button: "수정 완료",
   },
 };

--- a/src/components/common/InputTextareaForm/index.jsx
+++ b/src/components/common/InputTextareaForm/index.jsx
@@ -1,9 +1,7 @@
 import { useState } from "react";
-import { inputText } from "./constant";
 import styled from "styled-components";
-import boxStyles from "@styles/boxStyles";
-import colors from "@styles/colors";
-import fontStyles from "@styles/fontStyles";
+import { inputText } from "./constant";
+import { boxStyles, colors, fontStyles } from "@styles/styleVariables";
 import SubmitButton from "../SubmitButton";
 
 const BasicInputTextareaForm = ({ className, formType, handleSubmit, id }) => {
@@ -27,7 +25,7 @@ const BasicInputTextareaForm = ({ className, formType, handleSubmit, id }) => {
   };
 
   return (
-    <form onSubmit={onFormSubmit} className={className}>
+    <form onSubmit={onFormSubmit} className={className} name="content">
       <textarea
         onChange={handleChange}
         value={value}

--- a/src/components/common/InputTextareaForm/index.jsx
+++ b/src/components/common/InputTextareaForm/index.jsx
@@ -32,7 +32,7 @@ const BasicInputTextareaForm = ({ className, formType, handleSubmit, id }) => {
         onChange={handleChange}
         value={value}
         name="content"
-        placeholder={inputText[formType]?.placehodler}
+        placeholder={inputText[formType]?.placeholder}
       ></textarea>
       <SubmitButton isDisabled={isDisabled}>
         {inputText[formType]?.button}


### PR DESCRIPTION
## 개요
### 1. FeedContainer 수정
- FeedContainer를 호출할 때 cardType prop을 통해 별도 조작 없이 Feed 페이지와 Answer 페이지에서 출력될 카드컴포넌트를 구분하도록 수정했습니다.
- 53행 `<FeedCard />`에 원래 prop으로 전달받았던 것들을 그대로 작성해주시면 됩니다. (55행 참고)
- cardType prop의 기본값이 basicFeed이므로, 별도로 값을 입력하지 않고 `<FeedContainer />`처럼 사용한다면 Feed 페이지 카드컴포넌트가 렌더링됩니다. 

### 2. AnswerFeedCard 컴포넌트 기능 추가
- 답변 상태에 따라 answer content / TextareaForm이 출력됩니다.
- 답변이 없는 질문에 답변을 작성하고 submit하면 서버에서 정보를 받아와 바로 업데이트하도록 수정했습니다.
- 답변이 달린 질문에 더보기버튼->삭제하기를 누르면 답변이 삭제됩니다. (단 이건 바로 업데이트 되지 않아 한번 새로고침하여 확인해야해요. 추후 보완예정입니다~!)

### 3. 오탈자 수정
- 일부 오탈자를 수정하였습니다 .

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 연관된 ISSUE
issue #넘버
