### PR TITLE
design: 메인/피드/답변 페이지 스타일 수정 외 

### DIFF
--- a/src/Pages/AnswerPage/index.jsx
+++ b/src/Pages/AnswerPage/index.jsx
@@ -28,6 +28,7 @@ const AnswerPage = () => {
   useEffect(() => {
     const status = FeedDeleteResponse?.status;
     if (status && status >= 200 && status < 300) {
+      localStorage.removeItem("id");
       navigate("/");
     }
     // 로컬스토리지에 저장되어있던 Id 생성 정보를 삭제하는 로직 추가 필요

--- a/src/Pages/AnswerPage/index.jsx
+++ b/src/Pages/AnswerPage/index.jsx
@@ -34,7 +34,7 @@ const AnswerPage = () => {
   }, [FeedDeleteResponse]);
 
   return (
-    <FeedLayout id={id} feedType="answer">
+    <FeedLayout id={id} $feedType="answer">
       <DeleteFloatingButton handleDelete={handleFeedDelete} />
       <FeedContainer subjectId={id} cardType="answerFeed" />
     </FeedLayout>

--- a/src/Pages/AnswerPage/index.jsx
+++ b/src/Pages/AnswerPage/index.jsx
@@ -1,13 +1,11 @@
 import { useEffect } from "react";
-import { Link, useParams, useNavigate } from "react-router-dom";
-import styled from "styled-components";
-import boxStyles from "../../styles/boxStyles";
-import useDelete from "../../components/AnswerPage/MoreDropdown/useDelete";
+import { useParams, useNavigate } from "react-router-dom";
+import useDelete from "@components/AnswerPage/MoreDropdown/useDelete";
+import FeedLayout from "@layout/FeedLayout";
 import FeedContainer from "@components/common/FeedContainer";
 import DeleteFloatingButton from "@components/AnswerPage/DeleteFloatingButton";
 
 const AnswerPage = () => {
-  // 추후 삭제 확인 후 페이지 이동시 사용
   const navigate = useNavigate();
   const { id } = useParams();
 
@@ -36,19 +34,11 @@ const AnswerPage = () => {
   }, [FeedDeleteResponse]);
 
   return (
-    <Container>
-      <h1>답변 페이지</h1>
-      <Link to="/">메인 페이지</Link>
-      <Link to="/list">리스트 페이지</Link>
-      <Link to={`/post/${id}`}>피드 페이지</Link>
+    <FeedLayout id={id} feedType="answer">
       <DeleteFloatingButton handleDelete={handleFeedDelete} />
       <FeedContainer subjectId={id} cardType="answerFeed" />
-    </Container>
+    </FeedLayout>
   );
 };
-
-const Container = styled.div`
-  ${boxStyles.flexColumnCenter};
-`;
 
 export default AnswerPage;

--- a/src/Pages/FeedPage/index.jsx
+++ b/src/Pages/FeedPage/index.jsx
@@ -1,23 +1,16 @@
-import { Link } from "react-router-dom";
-import Modalsection from "../../components/FeedPage/ModalSection";
-import ShareButtons from "../../components/common/ShareButtons";
 import { useParams } from "react-router-dom";
-import FeedHeader from "../../components/FeedPage/FeedHeader";
-import FeedContainer from "../../components/common/FeedContainer";
+import Modalsection from "@components/FeedPage/ModalSection";
+import FeedContainer from "@components/common/FeedContainer";
+import FeedLayout from "@layout/FeedLayout";
 
 const FeedPage = () => {
   const { id } = useParams();
 
   return (
-    <div>
-      <Link to="/">메인 페이지</Link>
-      <Link to="/list">리스트 페이지</Link>
-      <Link to={`/post/${id}/answer`}>답변 페이지</Link>
-      <FeedHeader />
-      <ShareButtons id={id} />
+    <FeedLayout id={id} feedType="question">
       <FeedContainer subjectId={id} />
       <Modalsection subjectId={id} />
-    </div>
+    </FeedLayout>
   );
 };
 

--- a/src/Pages/FeedPage/index.jsx
+++ b/src/Pages/FeedPage/index.jsx
@@ -7,7 +7,7 @@ const FeedPage = () => {
   const { id } = useParams();
 
   return (
-    <FeedLayout id={id} feedType="question">
+    <FeedLayout id={id} $feedType="question">
       <FeedContainer subjectId={id} />
       <Modalsection subjectId={id} />
     </FeedLayout>

--- a/src/Pages/MainPage/index.jsx
+++ b/src/Pages/MainPage/index.jsx
@@ -1,21 +1,14 @@
-import { Link } from "react-router-dom";
-import SubmitButton from "../../components/common/SubmitButton";
-import logo from "../../assets/images/logo.svg";
-import backgroundImg from "../../assets/images/background-image.png";
-import useRequest from "../../hooks/useRequest";
-import { useNavigate } from "react-router-dom";
-import { useEffect } from "react";
-import { BASIC_SUBJECT, POST_URL } from "./constants";
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
 import styled from "styled-components";
-import {
-  colors,
-  boxStyles,
-  fontStyles,
-  devices,
-} from "../../styles/styleVariables";
-import personIcon from "../../assets/icons/Person.svg";
-import arrowRightBrown from "../../assets/icons/arrow-right-brown.svg";
+import { colors, boxStyles, fontStyles, devices } from "@styles/styleVariables";
+import useRequest from "@hooks/useRequest";
+import logo from "@images/logo.svg";
+import backgroundImg from "@images/background-image.png";
+import personIcon from "@icons/Person.svg";
+import arrowRightBrown from "@icons/arrow-right-brown.svg";
+import SubmitButton from "@components/common/SubmitButton";
+import { BASIC_SUBJECT, POST_URL } from "./constants";
 
 const MainPage = () => {
   const [value, setValue] = useState("");
@@ -64,45 +57,60 @@ const MainPage = () => {
 
   return (
     <ContainDiv>
-      <Header>
-        <img src={logo} />
-        <Link to="/list">
-          <button>
-            <p>질문하러 가기</p>
-            <img src={arrowRightBrown} />
-          </button>
-        </Link>
-      </Header>
-      <StyledDiv>
-        <StyledForm onSubmit={handleSubmitClick}>
-          <InputDiv>
-            <label htmlFor="name">
-              <img src={personIcon} />
-            </label>
-            <input
-              id="name"
-              placeholder="이름을 입력하세요"
-              onChange={handleChange}
-            />
-          </InputDiv>
-          <SubmitButton>질문 받기</SubmitButton>
-        </StyledForm>
-      </StyledDiv>
-      <Footer>
-        <img src={backgroundImg} />
-      </Footer>
+      <Container>
+        <Header>
+          <img src={logo} />
+          <Link to="/list">
+            <button>
+              <p>질문하러 가기</p>
+              <img src={arrowRightBrown} />
+            </button>
+          </Link>
+        </Header>
+        <StyledDiv>
+          <StyledForm onSubmit={handleSubmitClick}>
+            <InputDiv>
+              <label htmlFor="name">
+                <img src={personIcon} />
+              </label>
+              <input
+                id="name"
+                placeholder="이름을 입력하세요"
+                onChange={handleChange}
+              />
+            </InputDiv>
+            <SubmitButton>질문 받기</SubmitButton>
+          </StyledForm>
+        </StyledDiv>
+      </Container>
     </ContainDiv>
   );
 };
 
 const ContainDiv = styled.div`
   background: ${colors.gray20};
+  width: 100%;
+  height: 100vh;
+  ${boxStyles.flexColumnCenter};
+`;
+
+const Container = styled.div`
+  background-image: url(${backgroundImg});
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: center bottom;
+  width: 100%;
+  height: 100vh;
+  ${boxStyles.flexColumnCenter};
+  justify-content: center;
+  @media ${devices.desktop} {
+    max-width: 1200px;
+  }
 `;
 
 const Header = styled.div`
   ${boxStyles.flexColumnCenter}
   margin-bottom: 24px;
-  padding-top: 80px;
   gap: 24px;
   background: ${colors.gray20};
 
@@ -167,40 +175,13 @@ const Header = styled.div`
   }
 `;
 
-const Footer = styled.div`
-  width: 100%;
-  height: 195px;
-  background: ${colors.gray20};
-  overflow: hidden;
-  position: relative;
-
-  img {
-    width: 100%;
-    height: 239px;
-    object-fit: contain;
-    object-position: center bottom;
-    position: absolute;
-    bottom: 0px;
-  }
-
-  @media ${devices.tablet} {
-    height: 296px;
-
-    img {
-      height: 401px;
-    }
-  }
-
-  @media ${devices.desktop} {
-    img {
-      height: 627px;
-    }
-  }
-`;
-
 const StyledDiv = styled.div`
   ${boxStyles.flexRowCenter};
-  background: ${colors.gray20};
+  padding-bottom: 64px;
+
+  @media ${devices.tablet} {
+    padding-bottom: 100px;
+  }
 `;
 
 const StyledForm = styled.form`

--- a/src/components/AnswerPage/DeleteFloatingButton/index.jsx
+++ b/src/components/AnswerPage/DeleteFloatingButton/index.jsx
@@ -13,6 +13,7 @@ const BasicDeleteFloatingButton = ({ className, handleDelete }) => {
 const DeleteFloatingButton = styled(BasicDeleteFloatingButton)`
   ${boxStyles.paddingButtonS};
   ${boxStyles.inlineFlexRowCenter};
+  align-self: flex-end;
   ${fontStyles.deleteS};
   width: 70px;
   height: 25px;

--- a/src/components/FeedPage/FeedHeader/index.jsx
+++ b/src/components/FeedPage/FeedHeader/index.jsx
@@ -1,15 +1,13 @@
+import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
-import HeaderImg from "../../../assets/images/header-image.png";
-import logoImg from "../../../assets/images/logo.svg";
-import { useParams } from "react-router-dom";
-import useRequest from "../../../hooks/useRequest";
-import { useEffect } from "react";
-import ProfileImage from "../../common/ProfileImage";
+import HeaderImg from "@images/header-image.png";
+import logoImg from "@images/logo.svg";
+import useRequest from "@hooks/useRequest";
+import ProfileImage from "@components/common/ProfileImage";
+import { colors, devices, fontStyles } from "@styles/styleVariables";
 
-const FeedHeader = () => {
-  const { id } = useParams();
-
+const FeedHeader = ({ id }) => {
   const {
     data: ProfileData,
     error,
@@ -28,13 +26,18 @@ const FeedHeader = () => {
     <>
       <Header>
         <Container>
-          <Link to={"/"}>
-            <Logo src={logoImg} />
-          </Link>
-          <ProfileImage src={ProfileData?.imageSource} size="xxLarge" />
-          <Name>
-            {ProfileData?.name ?? <span>정보를 불러오는데 실패했습니다.</span>}
-          </Name>
+          <ImageContainer />
+          <HeaderContent>
+            <Link to={"/"}>
+              <Logo src={logoImg} />
+            </Link>
+            <ProfileImage src={ProfileData?.imageSource} size="xLarge" />
+            <Name>
+              {ProfileData?.name ?? (
+                <span>정보를 불러오는데 실패했습니다.</span>
+              )}
+            </Name>
+          </HeaderContent>
         </Container>
       </Header>
     </>
@@ -43,28 +46,57 @@ const FeedHeader = () => {
 
 export default FeedHeader;
 
-const Header = styled.div`
-  display: block;
-  justify-content: center;
+const ImageContainer = styled.div`
+  width: 100%;
+  height: 177px;
+  background-color: ${colors.gray10};
   background-image: url(${HeaderImg});
   background-position: top center;
-  background-size: auto;
+  background-size: 906px 177px;
   background-repeat: no-repeat;
 
-  @media (max-width: 1199px) {
-    background-size: 1200px;
+  @media ${devices.tablet} {
+    background-size: 1200px 234px;
+    height: 234px;
   }
 `;
 
+const HeaderContent = styled.div``;
+
+const Header = styled.div`
+  display: block;
+  justify-content: center;
+  width: 100%;
+`;
+
 const Container = styled.div`
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 12px;
+  gap: 1rem;
   width: 100%;
   height: auto;
-  padding-top: 50px;
-  margin-bottom: 10px;
+  padding-bottom: 82px;
+
+  @media ${devices.tablet} {
+    padding-bottom: 95px;
+  }
+
+  & ${HeaderContent} {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    position: absolute;
+    top: 40px;
+    left: 50%;
+    transform: translateX(-50%);
+
+    @media ${devices.tablet} {
+      top: 50px;
+    }
+  }
 `;
 
 const Logo = styled.img`
@@ -78,8 +110,10 @@ const Logo = styled.img`
 `;
 
 const Name = styled.p`
-  @media (max-width: 767px) {
-    font-size: 2.4rem;
-    line-height: 3rem;
+  ${fontStyles.h3};
+  ${fontStyles.regular};
+
+  @media ${devices.tablet} {
+    ${fontStyles.h2};
   }
 `;

--- a/src/components/FeedPage/ModalSection/index.jsx
+++ b/src/components/FeedPage/ModalSection/index.jsx
@@ -1,14 +1,9 @@
 import { useState, useRef, useEffect } from "react";
 import styled from "styled-components";
-import {
-  colors,
-  boxStyles,
-  fontStyles,
-  devices,
-} from "../../../styles/styleVariables";
+import { colors, boxStyles, fontStyles, devices } from "@styles/styleVariables";
 import ModalForm from "../ModalForm";
-import closeIcon from "../../../assets/icons/Close.svg";
-import messageIcon from "../../../assets/icons/Messages.svg";
+import closeIcon from "@/icons/Close.svg";
+import messageIcon from "@icons/Messages.svg";
 
 const Modal = ({ subjectId, setIsModalOpen }) => {
   const modalBg = useRef();
@@ -82,12 +77,6 @@ const Modalsection = ({ subjectId }) => {
 
 const Footer = styled.div`
   width: 100%;
-  height: 126px;
-  background: ${colors.gray20};
-
-  @media ${devices.tablet} {
-    height: 136px;
-  }
 `;
 
 const MobileButton = styled.button`

--- a/src/components/FeedPage/ModalSection/index.jsx
+++ b/src/components/FeedPage/ModalSection/index.jsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect } from "react";
 import styled from "styled-components";
 import { colors, boxStyles, fontStyles, devices } from "@styles/styleVariables";
 import ModalForm from "../ModalForm";
-import closeIcon from "@/icons/Close.svg";
+import closeIcon from "@icons/Close.svg";
 import messageIcon from "@icons/Messages.svg";
 
 const Modal = ({ subjectId, setIsModalOpen }) => {

--- a/src/components/common/FeedContainer/index.jsx
+++ b/src/components/common/FeedContainer/index.jsx
@@ -1,12 +1,12 @@
 import { useEffect } from "react";
 import styled from "styled-components";
 import useRequest from "@hooks/useRequest";
-import { boxStyles, colors, devices } from "@styles/styleVariables";
+import { boxStyles, colors } from "@styles/styleVariables";
 import FeedCountMessage from "@components/common/FeedCountMessage";
 import NoFeedCard from "@components/common/NoFeedCard";
 import AnswerFeedCard from "@components/AnswerPage/AnswerFeedCard";
-import FeedCard from "../FeedCard";
-import LoadingFeedCard from "../LoadingFeedCard";
+import FeedCard from "@components/common/FeedCard";
+import LoadingFeedCard from "@components/common/LoadingFeedCard";
 
 const BasicFeedContainer = ({
   className,
@@ -101,10 +101,6 @@ const FeedContainer = styled(BasicFeedContainer)`
     & > li {
       width: 100%;
     }
-  }
-
-  @media ${devices.tablet} {
-    max-width: 716px;
   }
 `;
 

--- a/src/components/common/ProfileImage/index.jsx
+++ b/src/components/common/ProfileImage/index.jsx
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { devices, boxStyles } from "@styled/styleVariables";
+import { devices, boxStyles } from "@styles/styleVariables";
 
 // 프로필이미지 사용하고싶은 곳에 api 호출을 하고
 

--- a/src/components/common/ProfileImage/index.jsx
+++ b/src/components/common/ProfileImage/index.jsx
@@ -1,4 +1,5 @@
 import styled from "styled-components";
+import { devices, boxStyles } from "@styled/styleVariables";
 
 // 프로필이미지 사용하고싶은 곳에 api 호출을 하고
 
@@ -26,10 +27,27 @@ const SIZES = {
 const Container = styled.div`
   width: ${({ $size }) => ($size ? SIZES[$size] : SIZES["Large"])}px;
   height: ${({ $size }) => ($size ? SIZES[$size] : SIZES["Large"])}px;
-  border-radius: 136px;
+  ${boxStyles.radiusC};
   overflow: hidden;
   flex-shrink: 0;
   text-align: center;
+
+  @media ${devices.tablet} {
+    width: ${({ $size }) => {
+      if ($size === "xLarge") {
+        return SIZES["xxLarge"];
+      } else {
+        return SIZES[$size];
+      }
+    }}px;
+    height: ${({ $size }) => {
+      if ($size === "xLarge") {
+        return SIZES["xxLarge"];
+      } else {
+        return SIZES[$size];
+      }
+    }}px;
+  }
 `;
 
 const Img = styled.img`

--- a/src/components/common/ShareButtons/index.jsx
+++ b/src/components/common/ShareButtons/index.jsx
@@ -28,14 +28,12 @@ const WrappedDiv = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 12px auto 54px;
 `;
 
 const ContainDiv = styled.div`
   display: inline-flex;
   align-items: flex-start;
   gap: 12px;
-
   button:hover {
     cursor: pointer;
   }

--- a/src/layout/FeedLayout/index.jsx
+++ b/src/layout/FeedLayout/index.jsx
@@ -1,0 +1,43 @@
+import styled from "styled-components";
+import { colors, devices, boxStyles } from "@styles/styleVariables";
+import FeedHeader from "@components/FeedPage/FeedHeader";
+import ShareButtons from "@components/common/ShareButtons";
+
+const FeedBasicLayout = ({ children, id, className, feedType }) => {
+  return (
+    <Container className={className} feedType={feedType}>
+      <FeedHeader id={id} />
+      <ShareButtons id={id} />
+      <ContainerWrap>{children}</ContainerWrap>
+    </Container>
+  );
+};
+
+const Container = styled.div`
+  ${boxStyles.flexColumnCenter};
+  background-color: ${colors.gray20};
+  min-height: 100vh;
+  gap: 12px;
+`;
+
+const ContainerWrap = styled.div`
+  ${boxStyles.flexColumnCenter};
+  gap: 12px;
+  width: 100%;
+  margin-bottom: 168px;
+  padding: 0 24px;
+
+  @media ${devices.tablet} {
+    max-width: 782px;
+    margin-bottom: 140px;
+    padding: 0 32px;
+  }
+`;
+
+const FeedLayout = styled(FeedBasicLayout)`
+  & ${ContainerWrap} {
+    margin-top: ${({ feedType }) => (feedType === "question" ? "42px" : "0px")};
+  }
+`;
+
+export default FeedLayout;

--- a/src/layout/FeedLayout/index.jsx
+++ b/src/layout/FeedLayout/index.jsx
@@ -3,9 +3,9 @@ import { colors, devices, boxStyles } from "@styles/styleVariables";
 import FeedHeader from "@components/FeedPage/FeedHeader";
 import ShareButtons from "@components/common/ShareButtons";
 
-const FeedBasicLayout = ({ children, id, className, feedType }) => {
+const FeedBasicLayout = ({ children, id, className, $feedType }) => {
   return (
-    <Container className={className} feedType={feedType}>
+    <Container className={className} $feedType={$feedType}>
       <FeedHeader id={id} />
       <ShareButtons id={id} />
       <ContainerWrap>{children}</ContainerWrap>
@@ -36,7 +36,8 @@ const ContainerWrap = styled.div`
 
 const FeedLayout = styled(FeedBasicLayout)`
   & ${ContainerWrap} {
-    margin-top: ${({ feedType }) => (feedType === "question" ? "42px" : "0px")};
+    margin-top: ${({ $feedType }) =>
+      $feedType === "question" ? "42px" : "0px"};
   }
 `;
 


### PR DESCRIPTION
## 개요
### 1. 피드 레이아웃 컴포넌트 생성
- 페이지 레이아웃 컴포넌트를 생성해 적용했습니다. 

### 2.  피드/답변 페이지 내부 컴포넌트 스타일 조정
- 시안과 동일하게 디자인 구현 하기 위해 피드/답변 페이지 내부 컴포넌트 스타일을 일부 조정하였습니다.
- import 경로 등 자잘한 수정도 일부 했습니다~

### 3. 메인 페이지 스타일 수정
- 스타일 적용하며 jsx 코드 부분도 일부 변경하였습니다!
- @suMin-97 메인페이지 내부 컴포넌트들 따로 컴포넌트 단위로 빼서 사용하는게 나을것같아요! (공통으로 만들지 않더라도)

### 4. 피드 삭제 후 로컬 스토리지 id 저장값 삭제 기능 추가
- 피드 전체를 삭제하면 로컬 스토리지에 저장했던 id 값도 삭제하도록 코드를 추가했습니다.

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 연관된 ISSUE
issue #넘버
