### PR TITLE
답변, 피드 페이지 subject 중복 요청 수정, intersectionObserver cleanup 함수 추가

### DIFF
--- a/src/Pages/AnswerPage/index.jsx
+++ b/src/Pages/AnswerPage/index.jsx
@@ -22,6 +22,13 @@ const AnswerPage = () => {
   });
 
   const {
+    data: subjectData,
+    error: subjectError,
+    isLoading: subjectDataLoading,
+    request: getSubjectData,
+  } = useRequest({ method: "GET", url: `subjects/${id}` });
+
+  const {
     data: feedCardData,
     isLoading,
     error,
@@ -47,11 +54,14 @@ const AnswerPage = () => {
   const { count, next, results: feedCardList } = feedCardData ?? {};
 
   useEffect(() => {
+    getSubjectData();
+  }, []);
+
+  useEffect(() => {
     getFeedCardData({
       limit: PAGE_LIMIT,
       offset: (page.curPage - 1) * PAGE_LIMIT,
     });
-    console.log(status);
     if (status === 404) {
       navigate("/not-found");
     }
@@ -78,7 +88,13 @@ const AnswerPage = () => {
   }, [deleteResponseStatus]);
 
   return (
-    <FeedLayout id={id} $feedType="answer">
+    <FeedLayout
+      id={id}
+      $feedType="answer"
+      subjectData={subjectData}
+      isLoading={subjectDataLoading}
+      error={subjectError}
+    >
       <DeleteFloatingButton handleDelete={handleFeedDelete} />
       <FeedContainer
         subjectId={id}
@@ -87,6 +103,7 @@ const AnswerPage = () => {
         count={count}
         isLoading={isLoading}
         error={error}
+        subjectData={subjectData}
       />
       <div ref={target} style={{ width: "100%", height: 30 }} />
     </FeedLayout>

--- a/src/Pages/FeedPage/index.jsx
+++ b/src/Pages/FeedPage/index.jsx
@@ -20,6 +20,13 @@ const FeedPage = () => {
   });
 
   const {
+    data: subjectData,
+    error: subjectError,
+    isLoading: subjectDataLoading,
+    request: getSubjectData,
+  } = useRequest({ method: "GET", url: `subjects/${id}` });
+
+  const {
     data: feedCardData,
     isLoading,
     error,
@@ -41,6 +48,10 @@ const FeedPage = () => {
   };
 
   const { count, next, results: feedCardList } = feedCardData ?? {};
+
+  useEffect(() => {
+    getSubjectData();
+  }, []);
 
   useEffect(() => {
     getFeedCardData({
@@ -74,16 +85,25 @@ const FeedPage = () => {
   }, [postQuestionResponse]);
 
   return (
-    <FeedLayout id={id} $feedType="question">
+    <FeedLayout
+      id={id}
+      $feedType="question"
+      subjectData={subjectData}
+      isLoading={subjectDataLoading}
+      error={subjectError}
+    >
       <FeedContainer
         feedCardList={feedDataList}
         count={count}
         isLoading={isLoading}
         error={error}
+        subjectData={subjectData}
       />
       <div ref={target} style={{ width: "100%", height: 30 }} />
       <ModalSection
-        subjectId={id}
+        subjectData={subjectData}
+        isLoading={subjectDataLoading}
+        error={subjectError}
         handleQuestionSubmit={handleQuestionSubmit}
       />
     </FeedLayout>

--- a/src/components/FeedPage/FeedHeader/index.jsx
+++ b/src/components/FeedPage/FeedHeader/index.jsx
@@ -1,27 +1,13 @@
-import { useEffect } from "react";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
+import { colors, devices, fontStyles } from "@styles/styleVariables";
 import HeaderImg from "@images/header-image.png";
 import logoImg from "@images/logo.svg";
-import useRequest from "@hooks/useRequest";
 import ProfileImage from "@components/common/ProfileImage";
-import { colors, devices, fontStyles } from "@styles/styleVariables";
-import LoadingHeader from "../../common/LoadingHeader";
+import LoadingHeader from "@components/common/LoadingHeader";
 
-const FeedHeader = ({ id }) => {
-  const {
-    data: ProfileData,
-    error,
-    isLoading,
-    request,
-  } = useRequest({
-    method: "GET",
-    url: `subjects/${id}`,
-  });
-
-  useEffect(() => {
-    request();
-  }, [id]);
+const FeedHeader = ({ subjectData, error, isLoading }) => {
+  const { imageSource, name } = subjectData ?? {};
 
   return (
     <>
@@ -36,11 +22,9 @@ const FeedHeader = ({ id }) => {
               <LoadingHeader />
             ) : (
               <>
-                <ProfileImage src={ProfileData?.imageSource} size="xLarge" />
+                <ProfileImage src={imageSource} size="xLarge" />
                 <Name>
-                  {ProfileData?.name ?? (
-                    <span>정보를 불러오는데 실패했습니다.</span>
-                  )}
+                  {error ? <span>정보를 불러오는데 실패했습니다.</span> : name}
                 </Name>
               </>
             )}

--- a/src/components/FeedPage/ModalForm/index.jsx
+++ b/src/components/FeedPage/ModalForm/index.jsx
@@ -1,8 +1,6 @@
 import { useState } from "react";
 import styled from "styled-components";
-import SubmitButton from "../../common/SubmitButton";
-import useRequest from "../../../hooks/useRequest";
-import { useEffect } from "react";
+import SubmitButton from "@components/common/SubmitButton";
 import BASIC_QUESTION from "./constant";
 import {
   colors,
@@ -14,19 +12,12 @@ import LoadingModalForm from "./LoadingModalForm";
 
 const BasicModalForm = ({
   className,
-  subjectId,
   setIsModalOpen,
   handleQuestionSubmit,
+  subjectData,
+  isLoading,
+  error,
 }) => {
-  const {
-    data: profileData,
-    error: profileError,
-    isLoading: profileIsLoading,
-    request: getRequest,
-  } = useRequest({
-    url: `subjects/${subjectId}`,
-    method: "GET",
-  });
   // const { request: postRequest } = useRequest({
   //   url: `subjects/${subjectId}/questions`,
   //   method: "POST",
@@ -34,6 +25,8 @@ const BasicModalForm = ({
   const [isDisabled, setIsDisabled] = useState(true);
   const [value, setValue] = useState("");
   const regex = /^[\s\S]*\S[\s\S]*$/; // 스페이스,엔터만 입력한 경우 같이 값은 있지만 사실상 내용이 없는 공란을 검사하는 정규식, false이면 공란임
+
+  const { imageSource, name } = subjectData ?? {};
 
   // const questionFormValidation = (value) => {
   //   BASIC_QUESTION.subjectId = subjectId;
@@ -70,27 +63,23 @@ const BasicModalForm = ({
     }
   };
 
-  useEffect(() => {
-    getRequest();
-  }, []);
-
   return (
     <form onSubmit={onQuestionSubmit} className={className}>
       <label htmlFor="question">
-        {profileIsLoading && (
+        {isLoading && (
           <ProfileDiv>
             <P>To.</P>
             <LoadingModalForm />
           </ProfileDiv>
         )}
-        {profileData && (
+        {subjectData && (
           <ProfileDiv>
             <P>To.</P>
-            <img src={profileData?.imageSource} draggable="false" />
-            <p>{profileData?.name}</p>
+            <img src={imageSource} draggable="false" />
+            <p>{name}</p>
           </ProfileDiv>
         )}
-        {profileError && (
+        {error && (
           <ProfileDiv>
             <P>To.</P>
             <p>삐빅 에러입니다</p>

--- a/src/components/FeedPage/ModalSection/index.jsx
+++ b/src/components/FeedPage/ModalSection/index.jsx
@@ -5,7 +5,13 @@ import { ReactComponent as CloseIcon } from "@icons/Close.svg";
 import { ReactComponent as MessageIcon } from "@icons/Messages.svg";
 import ModalForm from "../ModalForm";
 
-const Modal = ({ subjectId, setIsModalOpen, handleQuestionSubmit }) => {
+const Modal = ({
+  setIsModalOpen,
+  handleQuestionSubmit,
+  subjectData,
+  isLoading,
+  error,
+}) => {
   const modalBg = useRef();
 
   const handleBGCloseClick = (event) => {
@@ -53,15 +59,22 @@ const Modal = ({ subjectId, setIsModalOpen, handleQuestionSubmit }) => {
         </FlexDiv>
         <ModalForm
           setIsModalOpen={setIsModalOpen}
-          subjectId={subjectId}
           handleQuestionSubmit={handleQuestionSubmit}
+          subjectData={subjectData}
+          isLoading={isLoading}
+          error={error}
         />
       </ContentsBox>
     </DimDiv>
   );
 };
 
-const ModalSection = ({ subjectId, handleQuestionSubmit }) => {
+const ModalSection = ({
+  handleQuestionSubmit,
+  subjectData,
+  isLoading,
+  error,
+}) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleOpenClick = () => {
@@ -75,8 +88,10 @@ const ModalSection = ({ subjectId, handleQuestionSubmit }) => {
       {isModalOpen && (
         <Modal
           setIsModalOpen={setIsModalOpen}
-          subjectId={subjectId}
           handleQuestionSubmit={handleQuestionSubmit}
+          subjectData={subjectData}
+          isLoading={isLoading}
+          error={error}
         />
       )}
     </Footer>

--- a/src/components/common/FeedCardList/index.jsx
+++ b/src/components/common/FeedCardList/index.jsx
@@ -1,29 +1,21 @@
 import FeedCard from "@components/common/FeedCard";
 import LoadingFeedCard from "@components/common/LoadingFeedCard";
 import AnswerFeedCard from "@components/AnswerPage/AnswerFeedCard";
-import useRequest from "../../../hooks/useRequest";
-import { useEffect } from "react";
 
-const FeedCardList = ({ feedCardList, isLoading, cardType, className }) => {
-  const {
-    data: subjectData,
-    isLoading: IsUserDataLoading,
-    request: getSubjectData,
-  } = useRequest({
-    url: `subjects/${feedCardList[0]?.subjectId}`,
-  });
-
+const FeedCardList = ({
+  feedCardList,
+  isLoading,
+  cardType,
+  className,
+  subjectData,
+}) => {
   const { imageSource, name } = subjectData ?? {};
-
-  useEffect(() => {
-    getSubjectData();
-  }, []);
 
   return (
     <ul className={className}>
       {feedCardList?.map((data) => (
         <li key={data?.id}>
-          {isLoading && IsUserDataLoading ? (
+          {isLoading ? (
             <LoadingFeedCard />
           ) : cardType === "basicFeed" ? (
             <FeedCard

--- a/src/components/common/FeedContainer/index.jsx
+++ b/src/components/common/FeedContainer/index.jsx
@@ -11,6 +11,7 @@ const BasicFeedContainer = ({
   count,
   isLoading,
   error,
+  subjectData,
 }) => {
   const feedContent = () => {
     if (error) {
@@ -27,6 +28,7 @@ const BasicFeedContainer = ({
           feedCardList={feedCardList}
           isLoading={isLoading}
           cardType={cardType}
+          subjectData={subjectData}
         />
       );
     }

--- a/src/components/common/ShareButtons/index.jsx
+++ b/src/components/common/ShareButtons/index.jsx
@@ -1,30 +1,21 @@
 import { FacebookShareButton } from "react-share";
+import styled from "styled-components";
+import { colors } from "@styles/styleVariables";
+import { BASIC_DEPLOY_URL } from "@constants/constants";
 import UrlShareButton from "../UrlShareButton";
 import KakaoShareButton from "../KakaoShareButton";
-import { BASIC_DEPLOY_URL } from "../../../constants/constants";
-import styled from "styled-components";
-import FacebookIcon from "../../../assets/icons/Facebook.svg";
-import { colors } from "../../../styles/styleVariables";
-import { useEffect } from "react";
-import useRequest from "../../../hooks/useRequest";
+import FacebookIcon from "@icons/Facebook.svg";
 
-const ShareButtons = ({ id }) => {
+const ShareButtons = ({ id, subjectData }) => {
   const url = `${BASIC_DEPLOY_URL}/post/${id}`;
-  const NAME_URL = `subjects/${id}`;
-  const { data, request: getName } = useRequest({
-    url: NAME_URL,
-    method: "GET",
-  });
 
-  useEffect(() => {
-    getName();
-  }, []);
+  const { name } = subjectData ?? {};
 
   return (
     <WrappedDiv>
       <ContainDiv>
         <UrlShareButton url={url} />
-        <KakaoShareButton url={url} subjectName={data?.name} />
+        <KakaoShareButton url={url} subjectName={name} />
         <FacebookShareButton url={url}>
           <StyledDiv>
             <img src={FacebookIcon} draggable="false" />

--- a/src/hooks/useIntersectionObserver.js
+++ b/src/hooks/useIntersectionObserver.js
@@ -1,5 +1,4 @@
-import { useState } from "react";
-import { useRef } from "react";
+import { useRef, useCallback, useEffect } from "react";
 
 const useIntersectionObserver = (callbackFn) => {
   const observer = useRef(
@@ -15,13 +14,19 @@ const useIntersectionObserver = (callbackFn) => {
     )
   );
 
-  const observe = (element) => {
+  const observe = useCallback((element) => {
     observer.current.observe(element);
-  };
+  }, []);
 
   const unobserve = (element) => {
     observer.current.unobserve(element);
   };
+
+  useEffect(() => {
+    return () => {
+      observer.current.disconnect();
+    };
+  }, []);
 
   return [observe, unobserve];
 };

--- a/src/layout/FeedLayout/index.jsx
+++ b/src/layout/FeedLayout/index.jsx
@@ -3,11 +3,23 @@ import { colors, devices, boxStyles } from "@styles/styleVariables";
 import FeedHeader from "@components/FeedPage/FeedHeader";
 import ShareButtons from "@components/common/ShareButtons";
 
-const FeedBasicLayout = ({ children, id, className, $feedType }) => {
+const FeedBasicLayout = ({
+  children,
+  id,
+  subjectData,
+  className,
+  $feedType,
+  isLoading,
+  error,
+}) => {
   return (
     <Container className={className} $feedType={$feedType}>
-      <FeedHeader id={id} />
-      <ShareButtons id={id} />
+      <FeedHeader
+        subjectData={subjectData}
+        isLoading={isLoading}
+        error={error}
+      />
+      <ShareButtons id={id} subjectData={subjectData} />
       <ContainerWrap>{children}</ContainerWrap>
     </Container>
   );

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,7 @@ export default defineConfig({
       { find: "@styles", replacement: "/src/styles" },
       { find: "@icons", replacement: "/src/assets/icons" },
       { find: "@images", replacement: "/src/assets/images" },
+      { find: "@constants", replacement: "/src/constants" },
     ],
   },
 });


### PR DESCRIPTION
## 개요
### 1. 답변, 피드페이지 `subject data` 중복 요청 수정
- 각각의 컴포넌트에서 불필요하게 3~4번 추가 데이터 `request`를 보냈던 것을 페이지 컴포넌트에서 한 번만 `request`하고 자식 컴포넌트에게 `prop`으로 전달하도록 수정했습니다.
- 모달섹션, 모달폼, 공유버튼, 피드헤더, 피드컨테이너, 답변페이지, 피드페이지 등등을 통합적으로 수정하였습니다. 
- @suMin-97 `request` 관련 로직만 수정/삭제하였는데 제가 확인했을 땐 오류 없었지만 혹시 모르니까 확인 부탁드려요! (수민님이 먼저 주석처리해둔 코드들은 손대지 않았습니다~! 나중에 체크하고 안쓰는 주석 코드는 삭제해주세요)

### 2. `intersectionObserver` 훅 내부에 `cleanup` 함수 추가
- `unmount`시 `disconnect`되도록 `cleanup`함수를 추가했습니다. 실제로 작동하는지는.. 잘모르겠는데 아마 되는것같습니다..

## PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 연관된 ISSUE
issue #넘버
